### PR TITLE
add libglu1-mesa-dev as a dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -34,6 +34,7 @@
   <depend>udev</depend>
   <depend>libglfw3-dev</depend>
   <depend>opengl</depend>
+  <depend>libglu1-mesa-dev</depend>
   <depend>gtk3</depend>
 
   <export>


### PR DESCRIPTION
Our CI cannot resolve opengl properly, it installs only the first dependency.