### PR TITLE
Update gitignore fore ubuntu-bionic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin/
 lib/
 
+ubuntu-bionic-master/
 ubuntu-xenial/
 ubuntu-xenial-hwe/
 


### PR DESCRIPTION
The ubuntu-bionic-master folder is created when the UVC kernel script is run. This just adds it to the gitignore.