### PR TITLE
Dissable openmp with cmake flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ os_set_flags()
 # macro definition located at "CMake/global_config.cmake"
 global_set_flags()
 
+# Disable OPENMP, see issue 1105
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBUILD_WITH_OPENMP=false")
+
 find_package(catkin REQUIRED)
 
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
As documented [here](https://github.com/IntelRealSense/librealsense/issues/1105) and [here](https://github.com/IntelRealSense/librealsense/issues/1662#issuecomment-387083795) disabling Openmp can result in a massive boost to performance. This change alone resulted in one CPU core using 100% -> 50% for simply streaming data on my laptop.